### PR TITLE
Fix to bug of having wrong start position of iterator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 3.4.0)
 project (ForestDB)
 
 IF (${CMAKE_MAJOR_VERSION} GREATER 2)


### PR DESCRIPTION
* If the start key of an iterator is greater then the skipped common
prefix of a B+tree, HB+trie iterator should go back to the parent
B+tree and pick the next entry of it.

* The same thing should be done for backward move.