### PR TITLE
Some fixes found building with GCC-11

### DIFF
--- a/src/hbtrie.cc
+++ b/src/hbtrie.cc
@@ -1487,8 +1487,10 @@ static hbtrie_result _hbtrie_find(struct hbtrie *trie, void *key, int keylen,
                                 btree->root_bid,
                                 trie->root_bid,
                                 offset);
+#if defined(WIN32) || defined(_WIN32)
                         free(docrawkey);
                         free(dockey);
+#endif
                         return HBTRIE_RESULT_INDEX_CORRUPTED;
                     }
 

--- a/tests/stats-agg/stat_aggregator.cc
+++ b/tests/stats-agg/stat_aggregator.cc
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iterator>
+#include <limits>
 #include <numeric>
 #include <string>
 


### PR DESCRIPTION
* Should not deallocate memory allocated with `alloca` using `free`.
* Missing include for numerical limits.