### PR TITLE
Fix to bug in bottom-up builder

### DIFF
--- a/src/internal_types.h
+++ b/src/internal_types.h
@@ -269,6 +269,25 @@ struct _fdb_key_cmp_info {
     struct kvs_info *kvs;
 };
 
+struct bottom_up_build_ctx {
+    /**
+     * List of <key, seqnum, offset> tuples to build the index.
+     */
+    struct list* entries;
+    /**
+     * Number of entries in `entries`.
+     */
+    uint64_t num_entries;
+    /**
+     * Amount of data appended in bottom-up mode.
+     */
+    uint64_t space_used;
+    /**
+     * ForestDB KV store handle.
+     */
+    fdb_kvs_handle *handle;
+};
+
 /**
  * ForestDB KV store handle definition.
  */
@@ -307,7 +326,7 @@ struct _fdb_kvs_handle {
         dirty_updates = kv_handle.dirty_updates;
         node = kv_handle.node;
         num_iterators = kv_handle.num_iterators;
-        bottom_up_build_entries = kv_handle.bottom_up_build_entries;
+        bub_ctx = kv_handle.bub_ctx;
         return *this;
     }
 
@@ -435,18 +454,8 @@ struct _fdb_kvs_handle {
     uint32_t num_iterators;
     /**
      * Used when `bottom_up_index_build` is `true`.
-     * Instead of inserting into the WAL, it keeps <key, seqnum, offset> tuples
-     * to build the index.
      */
-    struct list* bottom_up_build_entries;
-    /**
-     * The number of entries in `bottom_up_build_entries`.
-     */
-    uint64_t num_bottom_up_build_entries;
-    /**
-     * The amount of data appended in bottom-up mode.
-     */
-    uint64_t space_used_for_bottom_up_build;
+    struct bottom_up_build_ctx bub_ctx;
 };
 
 struct bottom_up_build_entry {

--- a/tests/functional/fdb_functional_test.cc
+++ b/tests/functional/fdb_functional_test.cc
@@ -5281,6 +5281,21 @@ void bottom_up_build_test()
         TEST_CHK( memcmp(value, value_out, valuelen_out) == 0 );
     }
 
+    // Search by seq-iterator from the middle.
+    fdb_iterator* itr = NULL;
+    s = fdb_iterator_sequence_init(default_db, &itr, 50, 100, FDB_ITR_NONE);
+    TEST_CHK(s == FDB_RESULT_SUCCESS);
+
+    fdb_seqnum_t seqnum_cnt = 50;
+    do {
+        fdb_doc* doc = NULL;
+        s = fdb_iterator_get(itr, &doc);
+        if (s != FDB_RESULT_SUCCESS) break;
+        TEST_CHK(doc->seqnum == seqnum_cnt);
+        seqnum_cnt++;
+        fdb_doc_free(doc);
+    } while (fdb_iterator_next(itr) == FDB_RESULT_SUCCESS);
+
     s = fdb_kvs_close(default_db);
     TEST_CHK(s == FDB_RESULT_SUCCESS);
 


### PR DESCRIPTION
* Seq-tree should have prefix of chunk size, in front of each sequence number.